### PR TITLE
AST-21193

### DIFF
--- a/internal/process.go
+++ b/internal/process.go
@@ -417,9 +417,9 @@ func fetchPresetsData(
 		return errors.Wrap(listErr, "error with getting preset list")
 	}
 	presetList = filterPresetList(presetList)
-	if len(projects) > 0 && projectsIds != "" {
-		log.Info().Msg("filtering presets, only export associated to projects")
+	if projectsIds != "" {
 		presetList = filterPresetByProjectList(presetList, projects)
+		log.Info().Msgf("%d associated presets found", len(presetList))
 	}
 	if err := exporter.CreateDir(export2.PresetsDirName); err != nil {
 		return err


### PR DESCRIPTION
- Removed empty project condition from presets filter.

By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../CODE-OF-CONDUCT.md). Please see the [contributing guidelines](../CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

- Added new filter presets, to only include the ones associated to projects.
- When Project IDs is not defined exports all presets.

### References

AST-21193

### Testing

To test :

- Go to SAST create one custom Preset, associated to one project and run CLI passing in args that project ID, should return only the presets associated to projects (excluding all base/default for now).
- Run CLI without project IDs args and should return all presets (excluding all base/default for now)
- If only define one project ID and not exists in SAST, presets will return empty array.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used
