### PR TITLE
AST-24901: Added new REST engineServers endpoint to fetch CxVersion w…

### DIFF
--- a/internal/app/export/transform.go
+++ b/internal/app/export/transform.go
@@ -121,7 +121,7 @@ func TransformEngineServers(servers []*rest.EngineServer) []*common.Installation
 		out = append(out, &common.InstallationMapping{
 			Name:    installationEngineServiceName,
 			Version: servers[0].CxVersion,
-			Hotfix:  "0",
+			Hotfix:  "",
 		})
 	} else if len(servers) > 1 {
 		for _, e := range servers {
@@ -130,7 +130,7 @@ func TransformEngineServers(servers []*rest.EngineServer) []*common.Installation
 					out = append(out, &common.InstallationMapping{
 						Name:    installationEngineServiceName,
 						Version: e.CxVersion,
-						Hotfix:  "0",
+						Hotfix:  "",
 					})
 				}
 			}

--- a/internal/app/export/transform_test.go
+++ b/internal/app/export/transform_test.go
@@ -342,7 +342,7 @@ func TestTransformEngineServers(t *testing.T) {
 			{
 				Name:    "Checkmarx Engine Service",
 				Version: "9.3.4.1111",
-				Hotfix:  "0",
+				Hotfix:  "",
 			},
 		}
 
@@ -364,7 +364,7 @@ func TestTransformEngineServers(t *testing.T) {
 			{
 				Name:    "Checkmarx Engine Service",
 				Version: "9.3.4.1111",
-				Hotfix:  "0",
+				Hotfix:  "",
 			},
 		}
 

--- a/internal/integration/common/models.go
+++ b/internal/integration/common/models.go
@@ -1,0 +1,7 @@
+package common
+
+type InstallationMapping struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Hotfix  string `json:"hotFix"`
+}

--- a/internal/integration/rest/apiclient.go
+++ b/internal/integration/rest/apiclient.go
@@ -28,6 +28,7 @@ const (
 	reportsCheckStatusEndpoint    = "/CxRestAPI/help/reports/sastScan/%d/status"
 	reportsResultEndpoint         = "/CxRestAPI/help/reports/sastScan/%d"
 	createReportIDEndpoint        = "/CxRestAPI/help/reports/sastScan"
+	engineServersEndpoint         = "/CxRestAPI/help/sast/engineServers"
 
 	// ScanReportTypeXML defines SAST report type XML
 	ScanReportTypeXML = "XML"
@@ -50,6 +51,7 @@ type Client interface {
 	GetProjectsWithLastScanID(fromDate, teamName, projectsIds string, offset, limit int) (*[]ProjectWithLastScanID, error)
 	GetTriagedResultsByScanID(scanID int) (*[]TriagedScanResult, error)
 	CreateScanReport(scanID int, reportType string, retry Retry) ([]byte, error)
+	GetEngineServers() ([]*EngineServer, error)
 }
 
 type RetryableHTTPAdapter interface {
@@ -412,4 +414,22 @@ func (c *APIClient) CreateScanReport(scanID int, reportType string, retry Retry)
 		}
 	}
 	return []byte{}, fmt.Errorf("failed getting report after %d attempts", retry.Attempts)
+}
+
+func (c *APIClient) GetEngineServers() ([]*EngineServer, error) {
+	url := fmt.Sprintf("%s%s", c.BaseURL, engineServersEndpoint)
+	req, requestErr := CreateRequest(http.MethodGet, url, nil, c.Token)
+	if requestErr != nil {
+		return nil, requestErr
+	}
+	body, getErr := c.getResponseBodyFromRequest(req)
+	if getErr != nil {
+		return nil, getErr
+	}
+	var response []*EngineServer
+	unmarshalErr := json.Unmarshal(body, &response)
+	if unmarshalErr != nil {
+		return nil, unmarshalErr
+	}
+	return response, nil
 }

--- a/internal/integration/rest/apiclient_test.go
+++ b/internal/integration/rest/apiclient_test.go
@@ -596,6 +596,86 @@ func TestAPIClient_GetProjects(t *testing.T) {
 	})
 }
 
+func TestAPIClient_GetEngineServers(t *testing.T) {
+	t.Run("returns engine servers response", func(t *testing.T) {
+		//nolint:lll
+		responseJSON := `[ { 
+								"id": 1, 
+								"name": "Localhost", 
+								"uri": "http://localhost:8088/", 
+								"minLoc": 0, 
+								"maxLoc": 999999999, 
+								"maxScans": 3,
+								"cxVersion": "9.3.0.1139", 
+								"status": { 
+									"id": 4, 
+									"value": "Idle" 
+								}, 
+								"link": { 
+									"rel": "self", 
+									"uri": "/sast/engineServers/1" 
+								} 
+						} ]`
+
+		client, clientErr := newMockClient(makeOkResponse(responseJSON)) //nolint:bodyclose
+		assert.NoError(t, clientErr)
+
+		result, err := client.GetEngineServers()
+		assert.NoError(t, err)
+
+		assert.Len(t, result, 1)
+		assert.Equal(t, "Localhost", result[0].Name)
+		assert.Equal(t, "9.3.0.1139", result[0].CxVersion)
+	})
+	t.Run("returns engine servers multi response", func(t *testing.T) {
+		//nolint:lll
+		responseJSON := `[ { 
+								"id": 1, 
+								"name": "Localhost", 
+								"uri": "http://localhost:8088/", 
+								"minLoc": 0, 
+								"maxLoc": 999999999, 
+								"maxScans": 3,
+								"cxVersion": "9.3.0.1139", 
+								"status": { 
+									"id": 4, 
+									"value": "Idle" 
+								}, 
+								"link": { 
+									"rel": "self", 
+									"uri": "/sast/engineServers/1" 
+								} 
+						},{ 
+								"id": 2, 
+								"name": "Localhost", 
+								"uri": "http://localhost:8088/", 
+								"minLoc": 0, 
+								"maxLoc": 999999999, 
+								"maxScans": 3,
+								"cxVersion": "9.3.5.1139", 
+								"status": { 
+									"id": 4, 
+									"value": "Offline" 
+								}, 
+								"link": { 
+									"rel": "self", 
+									"uri": "/sast/engineServers/1" 
+								} 
+						} ]`
+		client, clientErr := newMockClient(makeOkResponse(responseJSON)) //nolint:bodyclose
+		assert.NoError(t, clientErr)
+
+		result, err := client.GetEngineServers()
+		assert.NoError(t, err)
+
+		assert.Len(t, result, 2)
+		assert.Equal(t, "Localhost", result[0].Name)
+		assert.Equal(t, "9.3.0.1139", result[0].CxVersion)
+		assert.Equal(t, "Localhost", result[1].Name)
+		assert.Equal(t, "9.3.5.1139", result[1].CxVersion)
+	})
+}
+
 func makeOkResponse(body string) *http.Response {
 	return &http.Response{
 		StatusCode: 200,

--- a/internal/integration/rest/models.go
+++ b/internal/integration/rest/models.go
@@ -137,4 +137,35 @@ type (
 		TeamFullPath           string `json:"teamFullPath"`
 		SamlAttributeValue     string `json:"samlAttributeValue"`
 	}
+
+	StatusEngineServer struct {
+		ID    int    `json:"id"`
+		Value string `json:"value"`
+	}
+
+	LinkEngineServer struct {
+		Rel string `json:"rel"`
+		URI string `json:"uri"`
+	}
+
+	OfflineReasonCodeEngineServer struct {
+		ID    int    `json:"id"`
+		Value string `json:"value"`
+	}
+
+	EngineServer struct {
+		ID                             int                           `json:"id"`
+		Name                           string                        `json:"name"`
+		URI                            string                        `json:"uri"`
+		MinLoc                         int                           `json:"minLoc"`
+		MaxLoc                         int                           `json:"maxLoc"`
+		MaxScans                       int                           `json:"maxScans"`
+		CxVersion                      string                        `json:"cxVersion"`
+		OperatingSystem                string                        `json:"operatingSystem"`
+		Status                         StatusEngineServer            `json:"status"`
+		Link                           LinkEngineServer              `json:"link"`
+		OfflineReasonCode              OfflineReasonCodeEngineServer `json:"offlineReasonCode"`
+		OfflineReasonMessage           string                        `json:"offlineReasonMessage"`
+		OfflineReasonMessageParameters string                        `json:"offlineReasonMessageParameters"`
+	}
 )

--- a/internal/integration/soap/models.go
+++ b/internal/integration/soap/models.go
@@ -253,10 +253,4 @@ type (
 		Xmlns                         string                        `xml:"xmlns,attr"`
 		GetInstallationSettingsResult GetInstallationSettingsResult `xml:"GetInstallationSettingsResult"`
 	}
-
-	InstallationMapping struct {
-		Name    string `json:"name"`
-		Version string `json:"version"`
-		Hotfix  string `json:"hotFix"`
-	}
 )

--- a/test/mocks/integration/rest/mock_client.go
+++ b/test/mocks/integration/rest/mock_client.go
@@ -64,6 +64,21 @@ func (mr *MockClientMockRecorder) CreateScanReport(arg0, arg1, arg2 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateScanReport", reflect.TypeOf((*MockClient)(nil).CreateScanReport), arg0, arg1, arg2)
 }
 
+// GetEngineServers mocks base method.
+func (m *MockClient) GetEngineServers() ([]*rest.EngineServer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEngineServers")
+	ret0, _ := ret[0].([]*rest.EngineServer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEngineServers indicates an expected call of GetEngineServers.
+func (mr *MockClientMockRecorder) GetEngineServers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEngineServers", reflect.TypeOf((*MockClient)(nil).GetEngineServers))
+}
+
 // GetLdapRoleMappings mocks base method.
 func (m *MockClient) GetLdapRoleMappings() ([]byte, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../CODE-OF-CONDUCT.md). Please see the [contributing guidelines](../CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Added new REST engineServers endpoint to fetch CxVersion when SOAP GetInstallationSettings() method is not returning the "Checkmarx Engine Service" or "Checkmarx Scans Manager".

### References

(https://checkmarx.atlassian.net/wiki/spaces/AID/pages/5981241403/SAST+exporter+technical+design)

### Testing

The tests must be done in SAST distributed architecture. To perform this test request one VM with 9.3 SAST version and install upgrades until SAST 9.6. 

To force use of SAST GET /CxRestAPI/help/sast/engineServers go to [InstallationMap] and if contains in Name **Checkmarx Engine Service** or **Checkmarx Scans Manager**, just update this name to something else, add a simple prefix and in that case will fetch data from that REST endpoint.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used
