### PR TITLE
[SAST-6076] Fix SimID calculation issue caused by conflicting source files in temp folder

### DIFF
--- a/internal/app/interfaces/source_file.go
+++ b/internal/app/interfaces/source_file.go
@@ -5,6 +5,7 @@ type SourceFileRepo interface {
 }
 
 type SourceFile struct {
+	ResultID   string
 	RemoteName string
 	LocalName  string
 }

--- a/internal/app/metadata/metadata_test.go
+++ b/internal/app/metadata/metadata_test.go
@@ -140,7 +140,7 @@ func TestMetadataFactory_GetMetadataForQueryAndResult(t *testing.T) {
 							{
 								PathID:           metaResult2.PathID,
 								SimilarityID:     metaResult2Data.SimilarityID,
-								ResultID:         metaResult1.ResultID,
+								ResultID:         metaResult2.ResultID,
 								SASTSimilarityID: similarityID2,
 							},
 						},


### PR DESCRIPTION
### Description

Fix incorrect SimID calculation due to conflicting source files in temp folder

The export tool previously saved all source files directly into the temp folder, leading to conflicts when multiple projects had source files with the same path (e.g., `src/blah.js`). If one project saved a file first, subsequent projects skipped saving their version of the file, even if the contents differed. This caused SimID calculations for subsequent projects to be incorrect as they were based on the wrong source code.

This fix ensures that source files are saved with a project-specific structure in the temp folder, preventing conflicts and guaranteeing accurate SimID calculations for all projects.

### References

https://checkmarx.atlassian.net/browse/SAST-6076
Fork -> https://github.com/michaelkubiaczyk/sast-to-ast-export-mk

### Testing

Fixed sorting error in previous testing failing when there was comparison between the expected and actual SASTSimilarityID values were mismatched

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
