### PR TITLE
SAST-6242 | New flag remove problematic files

### DIFF
--- a/cmd/args.go
+++ b/cmd/args.go
@@ -2,12 +2,16 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/checkmarxDev/ast-sast-export/internal"
+	"github.com/rs/zerolog/log"
 
 	"github.com/spf13/cobra"
 )
 
+//nolint:gocyclo,funlen
 func GetArgs(cmd *cobra.Command, productName string) internal.Args {
 	args := internal.Args{}
 	args.ProductName = productName
@@ -64,6 +68,26 @@ func GetArgs(cmd *cobra.Command, productName string) internal.Args {
 	args.SimIDVersion, err = cmd.Flags().GetInt(simIDVersionArg)
 	if err != nil {
 		panic(err)
+	}
+	args.ExcludeFile, err = cmd.Flags().GetString(excludeFileArg)
+	if err != nil {
+		panic(err)
+	}
+	if args.ExcludeFile != "" {
+		if _, err := os.Stat(args.ExcludeFile); os.IsNotExist(err) {
+			log.Fatal().Msgf("Exclude file '%s' does not exist", args.ExcludeFile)
+		}
+		if filepath.Ext(args.ExcludeFile) != ".txt" {
+			log.Fatal().Msgf("Exclude file '%s' must be a .txt file", args.ExcludeFile)
+		}
+		fileContent, err := os.ReadFile(args.ExcludeFile)
+		if err != nil {
+			log.Fatal().Err(err).Msgf("Error reading exclude file: %s", args.ExcludeFile)
+		}
+		excludePaths := strings.Split(string(fileContent), "\n")
+		for i := range excludePaths {
+			excludePaths[i] = strings.TrimSpace(excludePaths[i])
+		}
 	}
 	return args
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ const (
 	queryMappingPathDefault = "https://raw.githubusercontent.com/Checkmarx/sast-to-ast-export/master/data/mapping.json"
 	nestedTeams             = "nested-teams"
 	simIDVersionArg         = "simIDVersion"
+	excludeFileArg          = "exclude-file"
 
 	projectsActiveSinceDefaultValue = 180
 	emptyProjectsActiveSince        = 0
@@ -140,6 +141,11 @@ func init() {
 		0,
 		"define version of the similarity ID calculation. Values: 0 - Default, 1 - Trim leading spaces, 2 - Remove all spaces.",
 	)
+	rootCmd.Flags().StringP(
+		excludeFileArg,
+		"",
+		"",
+		"TXT file with remote file paths or patterns to exclude from export; each line should contain a path or regex pattern.")
 
 	if err := rootCmd.MarkFlagRequired(userArg); err != nil {
 		panic(err)
@@ -151,6 +157,9 @@ func init() {
 		panic(err)
 	}
 	if err := rootCmd.MarkFlagCustom(projectsActiveSinceArg, projectsActiveSinceUsage); err != nil {
+		panic(err)
+	}
+	if err := rootCmd.MarkFlagFilename(excludeFileArg, "txt"); err != nil {
 		panic(err)
 	}
 }

--- a/internal/app/interfaces/source_file.go
+++ b/internal/app/interfaces/source_file.go
@@ -1,7 +1,11 @@
 package interfaces
 
 type SourceFileRepo interface {
-	DownloadSourceFiles(scanID string, sourceFiles []SourceFile) error
+	DownloadSourceFiles(scanID string, sourceFiles []SourceFile, rmvdir string) error
+}
+
+type ExcludeFile struct {
+	FileName string
 }
 
 type SourceFile struct {

--- a/internal/app/metadata/metadata.go
+++ b/internal/app/metadata/metadata.go
@@ -21,6 +21,7 @@ type Factory struct {
 	methodLineProvider   interfaces.MethodLineRepo
 	tmpDir               string
 	simIDVersion         int
+	rmvDir               string
 }
 
 func NewMetadataFactory(
@@ -30,6 +31,7 @@ func NewMetadataFactory(
 	methodLineProvider interfaces.MethodLineRepo,
 	tmpDir string,
 	simIDVersion int,
+	rmvDir string,
 ) *Factory {
 	return &Factory{
 		astQueryIDProvider,
@@ -38,6 +40,7 @@ func NewMetadataFactory(
 		methodLineProvider,
 		tmpDir,
 		simIDVersion,
+		rmvDir,
 	}
 }
 
@@ -82,7 +85,7 @@ func (e *Factory) GetMetadataRecord(scanID string, queries []*Query) (*Record, e
 				})
 			}
 		}
-		downloadErr := e.sourceProvider.DownloadSourceFiles(scanID, filesToDownload)
+		downloadErr := e.sourceProvider.DownloadSourceFiles(scanID, filesToDownload, e.rmvDir)
 		if downloadErr != nil {
 			return nil, errors.Wrap(downloadErr, "could not download source code")
 		}

--- a/internal/app/metadata/metadata_test.go
+++ b/internal/app/metadata/metadata_test.go
@@ -93,9 +93,9 @@ func TestMetadataFactory_GetMetadataForQueryAndResult(t *testing.T) {
 	).Return(metaResult2Data.SimilarityID, nil)
 	sourceProviderMock := mock_app_source_file.NewMockSourceFileRepo(ctrl)
 	sourceProviderMock.EXPECT().
-		DownloadSourceFiles(scanID, gomock.Any()).
+		DownloadSourceFiles(scanID, gomock.Any(), gomock.Eq("")).
 		DoAndReturn(
-			func(_ string, files []interfaces.SourceFile) error {
+			func(_ string, files []interfaces.SourceFile, rmvdir string) error {
 				expectedFiles := []string{
 					metaResult1.FirstNode.FileName,
 					metaResult1.LastNode.FileName,
@@ -107,6 +107,7 @@ func TestMetadataFactory_GetMetadataForQueryAndResult(t *testing.T) {
 					result = append(result, v.RemoteName)
 				}
 				assert.ElementsMatch(t, expectedFiles, result)
+				assert.Equal(t, "", rmvdir)
 				return nil
 			},
 		)
@@ -118,7 +119,7 @@ func TestMetadataFactory_GetMetadataForQueryAndResult(t *testing.T) {
 	methodLineProvider.EXPECT().
 		GetMethodLinesByPath(scanID, metaQuery.QueryID).
 		Return(methodLinesResult, nil)
-	metadata := NewMetadataFactory(astQueryIDProviderMock, similarityIDProviderMock, sourceProviderMock, methodLineProvider, tmpDir, 0)
+	metadata := NewMetadataFactory(astQueryIDProviderMock, similarityIDProviderMock, sourceProviderMock, methodLineProvider, tmpDir, 0, "")
 
 	result, err := metadata.GetMetadataRecord(scanID, []*Query{metaQuery})
 	assert.NoError(t, err)

--- a/internal/models.go
+++ b/internal/models.go
@@ -19,6 +19,8 @@ type Args struct {
 	QueryMappingFile string
 	NestedTeams      bool
 	SimIDVersion     int
+	ExcludeFile      string
+	ExcludeFiles     []string
 }
 
 type ReportJob struct {

--- a/internal/persistence/sourcefile/exclude.go
+++ b/internal/persistence/sourcefile/exclude.go
@@ -1,0 +1,58 @@
+package sourcefile
+
+import (
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// ReadExcludedPaths reads exclude file and returns paths and regex patterns
+func ReadExcludedPaths(filePath string) ([]string, []*regexp.Regexp, error) {
+	if filePath == "" {
+		return nil, nil, nil
+	}
+
+	fileContent, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "could not read exclude file")
+	}
+
+	lines := strings.Split(string(fileContent), "\n")
+	var excludePaths []string
+	var excludePatterns []*regexp.Regexp
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// If line starts and ends with '/', treat it as a regex
+		if strings.HasPrefix(line, "/") && strings.HasSuffix(line, "/") {
+			pattern := strings.Trim(line, "/")
+			regex, err := regexp.Compile(pattern)
+			if err != nil {
+				log.Warn().Msgf("Invalid regex pattern: %s", pattern)
+				continue
+			}
+			excludePatterns = append(excludePatterns, regex)
+		} else {
+			// Treat it as a simple string match
+			excludePaths = append(excludePaths, line)
+		}
+	}
+
+	return excludePaths, excludePatterns, nil
+}
+
+// IsExcluded checks if a given file is in the exclusion list
+func IsExcluded(path string, excludePaths []string) bool {
+	for _, exclude := range excludePaths {
+		if path == exclude {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/persistence/sourcefile/repo.go
+++ b/internal/persistence/sourcefile/repo.go
@@ -3,8 +3,11 @@ package sourcefile
 import (
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/checkmarxDev/ast-sast-export/internal/app/interfaces"
+	"github.com/rs/zerolog/log"
 
 	"github.com/checkmarxDev/ast-sast-export/internal/integration/soap"
 
@@ -25,10 +28,41 @@ func NewRepo(soapClient soap.Adapter) *Repo {
 	return &Repo{soapClient: soapClient}
 }
 
-func (e *Repo) DownloadSourceFiles(scanID string, sourceFiles []interfaces.SourceFile) error {
+//nolint:gocyclo
+func (e *Repo) DownloadSourceFiles(scanID string, sourceFiles []interfaces.SourceFile, rmvdir string) error {
+	// Check if rmvdir is provided
+	var excludePaths []string
+	var excludePatterns []*regexp.Regexp
+
+	if rmvdir != "" {
+		var err error
+		excludePaths, excludePatterns, err = ReadExcludedPaths(rmvdir)
+		if err != nil {
+			return err
+		}
+	}
+	// Use the IsExcluded function to check if a file should be excluded
+	isExcluded := func(path string) bool {
+		for _, exclude := range excludePaths {
+			if path == exclude || strings.Contains(path, exclude) {
+				return true
+			}
+		}
+		for _, pattern := range excludePatterns {
+			if pattern.MatchString(path) {
+				return true
+			}
+		}
+		return false
+	}
+
 	var batches []Batch
 	currentBatch := 0
 	for _, v := range sourceFiles {
+		if isExcluded(v.RemoteName) {
+			log.Info().Msgf("Excluding problematic file: %s", v.RemoteName)
+			continue
+		}
 		if len(batches) < currentBatch+1 {
 			batches = append(batches, Batch{LocalFiles: []string{}, RemoteFiles: []string{}})
 		}
@@ -40,6 +74,7 @@ func (e *Repo) DownloadSourceFiles(scanID string, sourceFiles []interfaces.Sourc
 			currentBatch++
 		}
 	}
+
 	for _, batch := range batches {
 		sourceResponse, sourceErr := e.soapClient.GetSourcesByScanID(scanID, batch.RemoteFiles)
 		if sourceErr != nil {

--- a/internal/process.go
+++ b/internal/process.go
@@ -166,6 +166,7 @@ func RunExport(args *Args) error {
 		methodLineRepo,
 		metadataTempDir,
 		args.SimIDVersion,
+		args.ExcludeFile,
 	)
 
 	addErr := addCustomQueryIDs(astQueryProvider, astQueryMappingProvider)

--- a/test/mocks/app/source_file/mock_provider.go
+++ b/test/mocks/app/source_file/mock_provider.go
@@ -40,15 +40,15 @@ func (m *MockSourceFileRepo) EXPECT() *MockSourceFileRepoMockRecorder {
 }
 
 // DownloadSourceFiles mocks base method.
-func (m *MockSourceFileRepo) DownloadSourceFiles(arg0 string, arg1 []interfaces.SourceFile) error {
+func (m *MockSourceFileRepo) DownloadSourceFiles(arg0 string, arg1 []interfaces.SourceFile, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DownloadSourceFiles", arg0, arg1)
+	ret := m.ctrl.Call(m, "DownloadSourceFiles", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DownloadSourceFiles indicates an expected call of DownloadSourceFiles.
-func (mr *MockSourceFileRepoMockRecorder) DownloadSourceFiles(arg0, arg1 any) *gomock.Call {
+func (mr *MockSourceFileRepoMockRecorder) DownloadSourceFiles(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadSourceFiles", reflect.TypeOf((*MockSourceFileRepo)(nil).DownloadSourceFiles), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadSourceFiles", reflect.TypeOf((*MockSourceFileRepo)(nil).DownloadSourceFiles), arg0, arg1, arg2)
 }


### PR DESCRIPTION
### Description

This PR introduces a new flag to support **excluding problematic remote files** from the export process. The flag allows users to provide a .txt file containing file paths or regex patterns to be excluded. Each line in the file represents a specific path or pattern to be skipped during the export operation, improving flexibility and efficiency in managing unwanted files.

Some files can contain bad encoded UTF8 characters, because they are minified or statically generated by a third party software, and SAST has limitations parsing this type of files and the results are always gibberish. To solve the issues the exporter was facing with the data loss and character-encoding/code-page issues this solution was developed.

Some examples:

**Using the flag:  (    --exclude-file .\trash.txt    )**

1. Exclude all .min.css and .min.js files:
/.*\.min\.(css|js)$/

Example Matches:
styles/main.min.css
scripts/bundle.min.js

2. Exclude swagger statically generated files: 
alc-swagger-ui-master/dist/
(It will remove the respective files bellow this folder)

3. Exclude specific file
alc-swagger-ui-master/dist/swagger-ui-standalone-preset.js


### References

[Jira Issue 
](https://checkmarx.atlassian.net/browse/SAST-6242)

### Testing

Unit tests were added to validate the exclusion logic using both exact file paths and regex patterns.
Manual testing with various file structures and patterns to ensure expected behavior.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
