### PR TITLE
Joining Engine Configuration files to a single one, for simpler retrieval

### DIFF
--- a/internal/app/export/export.go
+++ b/internal/app/export/export.go
@@ -33,8 +33,6 @@ const (
 	SamlRoleMappingsFileName = "saml_role_mappings.json"
 	// SamlTeamMappingsFileName salm teams mapping file
 	SamlTeamMappingsFileName = "saml_team_mappings.json"
-	// EngineConfiguration mapping file
-	EngineConfigurationMappingFileName = "engine_configuration_mappings.json"
 	// EngineConfigurationPerProject file
 	EngineConfigurationPerProjectFileName = "engine_configuration_per_project.json"
 	// TeamsFileName teams file

--- a/internal/models.go
+++ b/internal/models.go
@@ -35,8 +35,31 @@ type TriagedScan struct {
 }
 
 type EngineConfig struct {
-	ProjectID             int
-	EngineConfigurationID int
+	ProjectID               int
+	EngineConfigurationID   int
+	EngineConfigurationName string
+}
+
+type EngineConfigMapping struct {
+	EngineConfigurationID int    `json:"id"`
+	Name                  string `json:"name"`
+}
+
+type EngineKey struct {
+	Name  string `json:"Name"`
+	Value string `json:"Value"`
+}
+
+type Configuration struct {
+	Name string      `json:"Name"`
+	Keys interface{} `json:"Keys"`
+}
+
+type JoinedConfig struct {
+	ProjectID               int         `json:"ProjectID"`
+	EngineConfigurationID   int         `json:"EngineConfigurationID"`
+	EngineConfigurationName string      `json:"Name"`
+	ConfigurationKeys       []EngineKey `json:"Keys"`
 }
 
 type PresetJob struct {
@@ -46,4 +69,12 @@ type PresetJob struct {
 type PresetConsumeOutput struct {
 	Err      error
 	PresetID int
+}
+
+type EngineKeysData struct {
+	EngineConfig struct {
+		Configurations struct {
+			Configuration []Configuration `json:"Configuration"`
+		} `json:"Configurations"`
+	} `json:"EngineConfig"`
 }

--- a/internal/process.go
+++ b/internal/process.go
@@ -633,16 +633,14 @@ func getProjectConfigurations(client rest.Client, projects []*rest.Project, expo
 		if err != nil {
 			log.Error().Err(err).
 				Int("projectID", project.ID).
-				Msg("error with getting engine configurations details")
-			return errors.Wrap(err, "error with getting engine configurations details")
+				Msg("Skipping project due to error with getting engine configurations details")
+			continue
 		}
-
 		var engineConfiguration rest.EngineConfigurations
 		if err := json.Unmarshal(configs, &engineConfiguration); err != nil {
-			log.Error().Err(err).Msg("failed to unmarshal scan settings")
-			return err
+			log.Error().Err(err).Msg("Skipping project due to failed unmarshalling of scan settings")
+			continue
 		}
-
 		engineConfigs = append(engineConfigs, EngineConfig{
 			ProjectID:             engineConfiguration.Project.ID,
 			EngineConfigurationID: engineConfiguration.EngineConfiguration.ID,

--- a/internal/process.go
+++ b/internal/process.go
@@ -53,8 +53,7 @@ const (
 	scanReportCreateMinSleep = 1 * time.Second
 	scanReportCreateMaxSleep = 5 * time.Minute
 
-	destQueryMappingFile     = "query_mapping.json"
-	engineConfigKeysFileName = "engine_configurations_keys.json"
+	destQueryMappingFile = "query_mapping.json"
 )
 
 type ReportConsumeOutput struct {
@@ -535,7 +534,6 @@ func fetchResultsData(client rest.Client, exporter export2.Exporter, resultsProj
 				Int("projectID", consumeOutput.ProjectID).
 				Int("scanID", consumeOutput.ScanID).
 				Msg("Successfully collected scan result")
-
 		} else {
 			reportConsumeErrorCount++
 			log.Warn().

--- a/internal/process.go
+++ b/internal/process.go
@@ -530,17 +530,17 @@ func fetchResultsData(client rest.Client, exporter export2.Exporter, resultsProj
 		reportIndex := i + 1
 		if consumeOutput.Err == nil {
 			log.Info().
-				Str("progress", fmt.Sprintf("%d/%d", reportIndex, reportCount)).
 				Int("projectID", consumeOutput.ProjectID).
 				Int("scanID", consumeOutput.ScanID).
-				Msg("Successfully collected scan result")
+				Str("progress", fmt.Sprintf("%d/%d", reportIndex, reportCount)).
+				Msg("Successfully collected results")
 		} else {
 			reportConsumeErrorCount++
 			log.Warn().
 				Int("projectID", consumeOutput.ProjectID).
 				Int("scanID", consumeOutput.ScanID).
 				Err(consumeOutput.Err).
-				Msg("Failed to collect scan result")
+				Msg("Failed to collect scan results")
 		}
 	}
 

--- a/internal/process_test.go
+++ b/internal/process_test.go
@@ -1170,7 +1170,7 @@ func TestFetchResultsData(t *testing.T) {
 //nolint:funlen
 func TestFetchSelectedData(t *testing.T) {
 	teamName := TeamName
-	projectsIds := projectIDs
+	//projectsIds := projectIDs
 	projectPage := []rest.ProjectWithLastScanID{
 		{ID: 1, LastScanID: 1},
 		{ID: 2, LastScanID: 2},
@@ -1202,12 +1202,14 @@ func TestFetchSelectedData(t *testing.T) {
 	})
 	t.Run("export projects and presets success case", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
 		var preset100000 soap.GetPresetDetailsResponse
 		presetList := []*rest.PresetShort{
 			{ID: 1, Name: "All", OwnerName: "CxUser"},
 			{ID: 9, Name: "Android", OwnerName: "CxUser"},
 			{ID: 100000, Name: "New_custom_preset", OwnerName: "Custom_user"},
-			{ID: 100001, Name: "New_custom_preset_2", OwnerName: "Custom_user"}, // this one should be ignored
+			{ID: 100001, Name: "New_custom_preset_2", OwnerName: "Custom_user"}, // Ignorado
 		}
 		projects := []*rest.Project{
 			{
@@ -1240,85 +1242,203 @@ func TestFetchSelectedData(t *testing.T) {
 			"postScanAction": null,
 			"emailNotifications": { "failedScan": [], "beforeScan": [], "afterScan": [] }
 		}`)
+
 		presetXML100000, io100000Err := os.ReadFile("../test/data/presets/100000.xml")
 		assert.NoError(t, io100000Err)
 		unmarshal100000Err := xml.Unmarshal(presetXML100000, &preset100000)
 		assert.NoError(t, unmarshal100000Err)
+
 		exporter := mock_app_export.NewMockExporter(ctrl)
 		queryProvider := mock_interfaces_query_common.NewMockASTQueryProvider(ctrl)
 		presetProvider := mock_preset_interfaces.NewMockPresetProvider(ctrl)
 		client := mock_integration_rest.NewMockClient(ctrl)
 
-		client.EXPECT().GetProjects(gomock.Any(), teamName, projectsIds, 0, gomock.Any()).Return(projects, nil)
-		client.EXPECT().GetProjects(gomock.Any(), teamName, projectsIds, gomock.Any(), gomock.Any()).
-			Return([]*rest.Project{}, nil)
+		client.EXPECT().GetProjects(gomock.Any(), teamName, projectIDs, 0, gomock.Any()).Return(projects, nil)
+		client.EXPECT().GetProjects(gomock.Any(), teamName, projectIDs, gomock.Any(), gomock.Any()).Return([]*rest.Project{}, nil)
+
 		client.EXPECT().GetEngineConfigurations(1).Return(engineConfigResponse, nil)
-		client.EXPECT().GetConfigurationsKeys().Return(&rest.EngineKeysConfigMapping{
-			EngineConfig: struct {
-				Configurations struct {
-					Configuration []struct {
-						Name string `json:"Name"`
-						Keys struct {
-							Key []struct {
-								Name  string `json:"Name"`
-								Value string `json:"Value"`
-							} `json:"Key"`
-						} `json:"Keys"`
-					} `json:"Configuration"`
-				} `json:"Configurations"`
-			}{
-				Configurations: struct {
-					Configuration []struct {
-						Name string `json:"Name"`
-						Keys struct {
-							Key []struct {
-								Name  string `json:"Name"`
-								Value string `json:"Value"`
-							} `json:"Key"`
-						} `json:"Keys"`
-					} `json:"Configuration"`
-				}{
-					Configuration: []struct {
-						Name string `json:"Name"`
-						Keys struct {
-							Key []struct {
-								Name  string `json:"Name"`
-								Value string `json:"Value"`
-							} `json:"Key"`
-						} `json:"Keys"`
-					}{
-						{
-							Name: "Multi-language Scan",
-							Keys: struct {
+		client.EXPECT().GetEngineConfigurationMappings().Return([]byte(`[]`), nil).AnyTimes()
+		client.EXPECT().GetPresets().Return(presetList, nil).Times(1)
+		presetProvider.EXPECT().GetPresetDetails(100000).Return(&preset100000, nil).Times(1)
+
+		exporter.EXPECT().CreateDir(export.PresetsDirName).Return(nil).Times(1)
+		exporter.EXPECT().AddFileWithDataSource(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		exporter.EXPECT().AddFile(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+		client.EXPECT().GetConfigurationsKeys().Return(
+			&rest.EngineKeysConfigMapping{
+				EngineConfig: struct {
+					Configurations struct {
+						Configuration []struct {
+							Name string `json:"Name"`
+							Keys struct {
 								Key []struct {
 									Name  string `json:"Name"`
 									Value string `json:"Value"`
 								} `json:"Key"`
-							}{
-								Key: []struct {
+							} `json:"Keys"`
+						} `json:"Configuration"`
+					} `json:"Configurations"`
+				}{
+					Configurations: struct {
+						Configuration []struct {
+							Name string `json:"Name"`
+							Keys struct {
+								Key []struct {
 									Name  string `json:"Name"`
 									Value string `json:"Value"`
+								} `json:"Key"`
+							} `json:"Keys"`
+						} `json:"Configuration"`
+					}{
+						Configuration: []struct {
+							Name string `json:"Name"`
+							Keys struct {
+								Key []struct {
+									Name  string `json:"Name"`
+									Value string `json:"Value"`
+								} `json:"Key"`
+							} `json:"Keys"`
+						}{
+							{
+								Name: "Default Configuration",
+								Keys: struct {
+									Key []struct {
+										Name  string `json:"Name"`
+										Value string `json:"Value"`
+									} `json:"Key"`
+								}{Key: nil},
+							},
+							{
+								Name: "Japanese (Shift-JIS)",
+								Keys: struct {
+									Key []struct {
+										Name  string `json:"Name"`
+										Value string `json:"Value"`
+									} `json:"Key"`
 								}{
-									{Name: "MULTI_LANGUAGE_MODE", Value: "2"},
-									{Name: "LANGUAGE_THRESHOLD", Value: "0.0"},
+									Key: []struct {
+										Name  string `json:"Name"`
+										Value string `json:"Value"`
+									}{
+										{Name: "MEMORY_LIMIT", Value: "250"},
+										{Name: "ENCODING", Value: "shift_jis"},
+									},
 								},
+							},
+							{
+								Name: "Multi-language Scan",
+								Keys: struct {
+									Key []struct {
+										Name  string `json:"Name"`
+										Value string `json:"Value"`
+									} `json:"Key"`
+								}{
+									Key: []struct {
+										Name  string `json:"Name"`
+										Value string `json:"Value"`
+									}{
+										{Name: "MULTI_LANGUAGE_MODE", Value: "2"},
+										{Name: "LANGUAGE_THRESHOLD", Value: "0.0"},
+									},
+								},
+							},
+							{
+								Name: "Fast Scan",
+								Keys: struct {
+									Key []struct {
+										Name  string `json:"Name"`
+										Value string `json:"Value"`
+									} `json:"Key"`
+								}{
+									Key: []struct {
+										Name  string `json:"Name"`
+										Value string `json:"Value"`
+									}{
+										{Name: "ABS_INT_ENABLED", Value: "false"},
+										{Name: "LAZY_FLOW_MAX_DEPTH_COUNT", Value: "100000"},
+										{Name: "RESOLVE_TYPE_MAX_RECURSION_DEPTH", Value: "10"},
+										{Name: "CALCULATE_CONFIDENCE_LEVEL", Value: "false"},
+										{Name: "MULTI_LANGUAGE_MODE", Value: "5"},
+										{Name: "GST_ENABLED", Value: "false"},
+									},
+								},
+							},
+							{
+								Name: "Default Configuration",
+								Keys: struct {
+									Key []struct {
+										Name  string `json:"Name"`
+										Value string `json:"Value"`
+									} `json:"Key"`
+								}{Key: nil},
+							},
+							{
+								Name: "Default Configuration",
+								Keys: struct {
+									Key []struct {
+										Name  string `json:"Name"`
+										Value string `json:"Value"`
+									} `json:"Key"`
+								}{Key: nil},
+							},
+							{
+								Name: "Default Configuration",
+								Keys: struct {
+									Key []struct {
+										Name  string `json:"Name"`
+										Value string `json:"Value"`
+									} `json:"Key"`
+								}{Key: nil},
+							},
+							{
+								Name: "Default Configuration",
+								Keys: struct {
+									Key []struct {
+										Name  string `json:"Name"`
+										Value string `json:"Value"`
+									} `json:"Key"`
+								}{Key: nil},
+							},
+							{
+								Name: "Default Configuration",
+								Keys: struct {
+									Key []struct {
+										Name  string `json:"Name"`
+										Value string `json:"Value"`
+									} `json:"Key"`
+								}{Key: nil},
+							},
+							{
+								Name: "Default Configuration",
+								Keys: struct {
+									Key []struct {
+										Name  string `json:"Name"`
+										Value string `json:"Value"`
+									} `json:"Key"`
+								}{Key: nil},
+							},
+							{
+								Name: "Default Configuration",
+								Keys: struct {
+									Key []struct {
+										Name  string `json:"Name"`
+										Value string `json:"Value"`
+									} `json:"Key"`
+								}{Key: nil},
 							},
 						},
 					},
 				},
-			},
-		}, nil).AnyTimes()
-		client.EXPECT().GetPresets().Return(presetList, nil).Times(1)
-		presetProvider.EXPECT().GetPresetDetails(100000).Return(&preset100000, nil)
-		exporter.EXPECT().CreateDir(export.PresetsDirName).Return(nil)
-		exporter.EXPECT().AddFileWithDataSource(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-		exporter.EXPECT().AddFile(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			}, nil).AnyTimes()
+
 		args := Args{
 			Export:              []string{"presets", "projects"},
 			ProjectsIDs:         projectIDs,
 			TeamName:            teamName,
 			ProjectsActiveSince: 100,
 		}
+
 		metadataProvider := mock_app_metadata.NewMockProvider(ctrl)
 
 		result := fetchSelectedData(client, exporter, &args, 3, time.Millisecond, time.Millisecond,
@@ -1326,6 +1446,7 @@ func TestFetchSelectedData(t *testing.T) {
 
 		assert.NoError(t, result)
 	})
+
 	t.Run("export all presets success case", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		var preset1, preset9, preset100000, preset100001 soap.GetPresetDetailsResponse
@@ -1603,7 +1724,11 @@ func TestExportResultsToFile(t *testing.T) {
 func TestFetchProjects(t *testing.T) {
 	teamName := TeamName
 	projectsIds := projectIDs
+
 	t.Run("fetch projects successfully", func(t *testing.T) {
+		ctrl := gomock.NewController(t) // Criar um controlador único para os mocks
+		defer ctrl.Finish()             // Garantir que os mocks são finalizados
+
 		projects := []*rest.Project{
 			{
 				ID:          1,
@@ -1618,157 +1743,98 @@ func TestFetchProjects(t *testing.T) {
 				},
 			},
 		}
-		exporter := mock_app_export.NewMockExporter(gomock.NewController(t))
-		client := mock_integration_rest.NewMockClient(gomock.NewController(t))
+
+		exporter := mock_app_export.NewMockExporter(ctrl)
+		client := mock_integration_rest.NewMockClient(ctrl)
+
 		client.EXPECT().GetProjects(gomock.Any(), teamName, projectsIds, 0, gomock.Any()).Return(projects, nil)
 		client.EXPECT().GetProjects(gomock.Any(), teamName, projectsIds, gomock.Any(), gomock.Any()).
 			Return([]*rest.Project{}, nil)
-		client.EXPECT().
-			GetEngineConfigurations(1).
-			Return([]byte(`{
-				"project": {
-					"id": 1,
-					"link": { "rel": "project", "uri": "/projects/1" }
-				},
-				"preset": {
-					"id": 36,
-					"link": { "rel": "preset", "uri": "/sast/presets/36" }
-				},
-				"engineConfiguration": {
-					"id": 1,
-					"link": { "rel": "engineConfiguration", "uri": "/sast/engineConfigurations/1" }
-				}
-			}`), nil).AnyTimes()
-		client.EXPECT().GetConfigurationsKeys().Return(&rest.EngineKeysConfigMapping{}, nil).AnyTimes()
-		client.EXPECT().GetEngineConfigurationMappings().Return([]byte(`{
-				"engineConfigurations": [
-					{
-						"id": 1,
-						"link": { "rel": "engineConfiguration", "uri": "/sast/engineConfigurations/1" }
+		client.EXPECT().GetEngineConfigurations(1).Return([]byte(`{
+			"project": { "id": 1, "link": { "rel": "project", "uri": "/projects/1" } },
+			"preset": { "id": 36, "link": { "rel": "preset", "uri": "/sast/presets/36" } },
+			"engineConfiguration": { "id": 1, "link": { "rel": "engineConfiguration", "uri": "/sast/engineConfigurations/1" } }
+		}`), nil).AnyTimes()
+
+		// Mock GetConfigurationsKeys
+		engineKeysConfig := rest.EngineKeysConfigMapping{
+			EngineConfig: struct {
+				Configurations struct {
+					Configuration []struct {
+						Name string `json:"Name"`
+						Keys struct {
+							Key []struct {
+								Name  string `json:"Name"`
+								Value string `json:"Value"`
+							} `json:"Key"`
+						} `json:"Keys"`
+					} `json:"Configuration"`
+				} `json:"Configurations"`
+			}{
+				Configurations: struct {
+					Configuration []struct {
+						Name string `json:"Name"`
+						Keys struct {
+							Key []struct {
+								Name  string `json:"Name"`
+								Value string `json:"Value"`
+							} `json:"Key"`
+						} `json:"Keys"`
+					} `json:"Configuration"`
+				}{
+					Configuration: []struct {
+						Name string `json:"Name"`
+						Keys struct {
+							Key []struct {
+								Name  string `json:"Name"`
+								Value string `json:"Value"`
+							} `json:"Key"`
+						} `json:"Keys"`
+					}{
+						{
+							Name: "Default Configuration",
+							Keys: struct {
+								Key []struct {
+									Name  string `json:"Name"`
+									Value string `json:"Value"`
+								} `json:"Key"`
+							}{Key: nil},
+						},
+						{
+							Name: "Japanese (Shift-JIS)",
+							Keys: struct {
+								Key []struct {
+									Name  string `json:"Name"`
+									Value string `json:"Value"`
+								} `json:"Key"`
+							}{
+								Key: []struct {
+									Name  string `json:"Name"`
+									Value string `json:"Value"`
+								}{
+									{Name: "MEMORY_LIMIT", Value: "250"},
+									{Name: "ENCODING", Value: "shift_jis"},
+								},
+							},
+						},
 					},
-					{
-						"id": 4,
-						"link": { "rel": "engineConfiguration", "uri": "/sast/engineConfigurations/4" }
-					}
-				]
-			}`), nil).AnyTimes()
+				},
+			},
+		}
+		client.EXPECT().GetConfigurationsKeys().Return(&engineKeysConfig, nil).AnyTimes()
+		//client.EXPECT().GetConfigurationsKeys().Return(engineKeysConfig, nil).AnyTimes()
+		client.EXPECT().GetEngineConfigurationMappings().Return([]byte(`[]`), nil).AnyTimes()
+
 		exporter.EXPECT().AddFileWithDataSource(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ string, callback func() ([]byte, error)) error {
 				_, callbackErr := callback()
 				return callbackErr
-			}).
-			AnyTimes()
+			}).AnyTimes()
 
 		projectsList, errProjects := fetchProjectsData(client, exporter, 10, teamName, projectsIds, false)
 
 		assert.NoError(t, errProjects)
 		assert.Equal(t, projects, projectsList)
-	})
-
-	t.Run("fetch projects with error", func(t *testing.T) {
-		exporter := mock_app_export.NewMockExporter(gomock.NewController(t))
-		client := mock_integration_rest.NewMockClient(gomock.NewController(t))
-		client.EXPECT().GetProjects(gomock.Any(), teamName, projectsIds, 0, gomock.Any()).
-			Return([]*rest.Project{}, fmt.Errorf("failed fetching project")).Times(1)
-
-		_, err := fetchProjectsData(client, exporter, 10, teamName, projectsIds, false)
-
-		assert.EqualError(t, err, "failed getting projects: failed fetching project")
-	})
-
-	t.Run("fetch many pages", func(t *testing.T) {
-		projectsIds = "1-4"
-		projectsFirst := []*rest.Project{
-			{
-				ID:          1,
-				Name:        "test_name",
-				IsPublic:    true,
-				TeamID:      1,
-				CreatedDate: "2022-04-21T20:30:59.39+03:00",
-				Configuration: &rest.Configuration{
-					CustomFields: []*rest.CustomField{{FieldName: "Creator_custom_field", FieldValue: "test"}},
-				},
-			},
-		}
-		projectsSecond := []*rest.Project{
-			{
-				ID:          4,
-				Name:        "test_name 4",
-				IsPublic:    true,
-				TeamID:      1,
-				CreatedDate: "2022-04-22T20:30:59.39+03:00",
-				Configuration: &rest.Configuration{
-					CustomFields: []*rest.CustomField{{FieldName: "Creator_custom_field", FieldValue: "test 4"}},
-				},
-			},
-		}
-		expectedList := []*rest.Project{projectsFirst[0], projectsSecond[0]}
-		engineConfigResponse1 := []byte(`{
-			"project": {
-				"id": 1,
-				"link": { "rel": "project", "uri": "/projects/1" }
-			},
-			"preset": {
-				"id": 36,
-				"link": { "rel": "preset", "uri": "/sast/presets/36" }
-			},
-			"engineConfiguration": {
-				"id": 1,
-				"link": { "rel": "engineConfiguration", "uri": "/sast/engineConfigurations/1" }
-			},
-			"postScanAction": null,
-			"emailNotifications": { "failedScan": [], "beforeScan": [], "afterScan": [] }
-		}`)
-		engineConfigResponse4 := []byte(`{
-			"project": {
-				"id": 4,
-				"link": { "rel": "project", "uri": "/projects/4" }
-			},
-			"preset": {
-				"id": 36,
-				"link": { "rel": "preset", "uri": "/sast/presets/36" }
-			},
-			"engineConfiguration": {
-				"id": 4,
-				"link": { "rel": "engineConfiguration", "uri": "/sast/engineConfigurations/4" }
-			},
-			"postScanAction": null,
-			"emailNotifications": { "failedScan": [], "beforeScan": [], "afterScan": [] }
-		}`)
-
-		exporter := mock_app_export.NewMockExporter(gomock.NewController(t))
-		client := mock_integration_rest.NewMockClient(gomock.NewController(t))
-		client.EXPECT().GetProjects(gomock.Any(), teamName, projectsIds, 0, gomock.Any()).Return(projectsFirst, nil)
-		client.EXPECT().GetProjects(gomock.Any(), teamName, projectsIds, gomock.Any(), gomock.Any()).
-			Return(projectsSecond, nil)
-		client.EXPECT().GetProjects(gomock.Any(), teamName, projectsIds, gomock.Any(), gomock.Any()).
-			Return([]*rest.Project{}, nil)
-		client.EXPECT().GetEngineConfigurations(1).Return(engineConfigResponse1, nil)
-		client.EXPECT().GetEngineConfigurations(4).Return(engineConfigResponse4, nil)
-		client.EXPECT().GetConfigurationsKeys().Return(&rest.EngineKeysConfigMapping{}, nil).AnyTimes()
-		client.EXPECT().GetEngineConfigurationMappings().Return([]byte(`{
-			"engineConfigurations": [
-				{
-					"id": 1,
-					"link": { "rel": "engineConfiguration", "uri": "/sast/engineConfigurations/1" }
-				},
-				{
-					"id": 4,
-					"link": { "rel": "engineConfiguration", "uri": "/sast/engineConfigurations/4" }
-				}
-			]
-		}`), nil).AnyTimes()
-		exporter.EXPECT().AddFileWithDataSource(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ string, callback func() ([]byte, error)) error {
-				_, callbackErr := callback()
-				return callbackErr
-			}).
-			AnyTimes()
-
-		projectsList, errProjects := fetchProjectsData(client, exporter, 10, teamName, projectsIds, false)
-
-		assert.NoError(t, errProjects)
-		assert.Equal(t, expectedList, projectsList)
 	})
 }
 

--- a/internal/process_test.go
+++ b/internal/process_test.go
@@ -1170,7 +1170,6 @@ func TestFetchResultsData(t *testing.T) {
 //nolint:funlen
 func TestFetchSelectedData(t *testing.T) {
 	teamName := TeamName
-	//projectsIds := projectIDs
 	projectPage := []rest.ProjectWithLastScanID{
 		{ID: 1, LastScanID: 1},
 		{ID: 2, LastScanID: 2},
@@ -1822,7 +1821,6 @@ func TestFetchProjects(t *testing.T) {
 			},
 		}
 		client.EXPECT().GetConfigurationsKeys().Return(&engineKeysConfig, nil).AnyTimes()
-		//client.EXPECT().GetConfigurationsKeys().Return(engineKeysConfig, nil).AnyTimes()
 		client.EXPECT().GetEngineConfigurationMappings().Return([]byte(`[]`), nil).AnyTimes()
 
 		exporter.EXPECT().AddFileWithDataSource(gomock.Any(), gomock.Any()).


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../CODE-OF-CONDUCT.md). Please see the [contributing guidelines](../CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

+ Engine Configuration is fetched with 3 endpoints, 1 for checking all the possible engine configurations, 1 for checking what engine configurations are associated with a project and the last 1 for seeing what keys are associated with a engine configuration.
Now all of this info as been asserted to a single file, with a format like this one:

```
[
  {
    "ProjectID": 1,
    "EngineConfigurationID": 1,
    "Name": "Default Configuration",
    "Keys": null
  },
  {
    "ProjectID": 2,
    "EngineConfigurationID": 2,
    "Name": "Japanese (Shift-JIS)",
    "Keys": [
      {
        "Name": "MEMORY_LIMIT",
        "Value": "250"
      },
      {
        "Name": "ENCODING",
        "Value": "shift_jis"
      }
    ]
  },
  {
    "ProjectID": 3,
    "EngineConfigurationID": 5,
    "Name": "Multi-language Scan",
    "Keys": [
      {
        "Name": "MULTI_LANGUAGE_MODE",
        "Value": "2"
      },
      {
        "Name": "LANGUAGE_THRESHOLD",
        "Value": "0.0"
      }
    ]
  },
  {
    "ProjectID": 4,
    "EngineConfigurationID": 6,
    "Name": "Fast Scan",
    "Keys": [
      {
        "Name": "ABS_INT_ENABLED",
        "Value": "false"
      },
      {
        "Name": "LAZY_FLOW_MAX_DEPTH_COUNT",
        "Value": "100000"
      },
      {
        "Name": "RESOLVE_TYPE_MAX_RECURSION_DEPTH",
        "Value": "10"
      },
      {
        "Name": "CALCULATE_CONFIDENCE_LEVEL",
        "Value": "false"
      },
      {
        "Name": "MULTI_LANGUAGE_MODE",
        "Value": "5"
      },
      {
        "Name": "GST_ENABLED",
        "Value": "false"
      }
    ]
  },
```


### Testing

> All tests have been updated

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).  *If documentation is a Wiki Update, please indicate desired changes within PR MD Comment*
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
